### PR TITLE
Also patch /live/<id> and /watch/<id> URLs

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -40,6 +40,8 @@ browser.webRequest.onBeforeRequest.addListener(
   {
     urls: [
       "https://www.youtube.com/watch?*",
+      "https://www.youtube.com/watch/*",
+      "https://www.youtube.com/live/*",
       "https://www.youtube.com/youtubei/v1/player?*",
       "https://www.youtube.com/c/*/live",
     ],


### PR DESCRIPTION
This should fix some cases of the plugin not working with no apparent reason.

Looks like it's unrelated to the thing you are experiencing.